### PR TITLE
NINGG-17251: switch Google Pay to production

### DIFF
--- a/SimpleIntegration/android/build.gradle
+++ b/SimpleIntegration/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "34.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 31
-        targetSdkVersion = 31
+        compileSdkVersion = 34
+        targetSdkVersion = 35
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64

--- a/SimpleIntegration/android/gradle.properties
+++ b/SimpleIntegration/android/gradle.properties
@@ -31,6 +31,7 @@ FLIPPER_VERSION=0.125.0
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64
 reactNativeArchitectures=armeabi-v7a,arm64-v8a,x86,x86_64
+android.suppressUnsupportedCompileSdk=35
 
 # Use this property to enable support to the new architecture.
 # This will allow you to use TurboModules and the Fabric render in

--- a/SimpleIntegration/src/app.js
+++ b/SimpleIntegration/src/app.js
@@ -99,7 +99,7 @@ const App = () => {
       }
       // Check Google Pay availability
       try {
-        const isGooglePayEnabled = await isGooglePaySupported({ environment: 'TEST' });
+        const isGooglePayEnabled = await isGooglePaySupported({ environment: 'PRODUCTION' });
         setShowGooglePay(isGooglePayEnabled);
       } catch (e) {
         setShowGooglePay(false);
@@ -111,10 +111,10 @@ const App = () => {
     getWalletStatus();
   }, [getWalletStatus]);
 
-  // Create an order with value of 250234 AED
+  // Create an order with value of 1 AED
   const createFixedOrder = useCallback(
     async (token, savedCardDetails = null) => {
-      const order = await createOrder(token, 25023400, savedCardDetails); // 250234 AED = 25023400 fils
+      const order = await createOrder(token, 100, savedCardDetails); // 1 AED = 100 fils
       return order;
     },
     [],
@@ -292,7 +292,7 @@ const App = () => {
         merchantName: currentGooglePayConfig.merchantInfo?.name || 'Test Merchant',
         gateway: currentGooglePayConfig.gatewayName || 'networkintl',
         gatewayMerchantId: currentGooglePayConfig.merchantGatewayId || 'BCR2DN4T263KB4BO',
-        environment: currentGooglePayConfig.environment || 'TEST',
+        environment: currentGooglePayConfig.environment || 'PRODUCTION',
         merchantId: currentGooglePayConfig.merchantGatewayId || 'BCR2DN4T263KB4BO',
         merchantOrigin: currentGooglePayConfig.merchantOrigin || 'http://applePayChub.com',
       });
@@ -372,7 +372,7 @@ const App = () => {
         disabled={creatingOrder}
         style={StyleSheet.compose(styles.button, disabledStyle)}
         onPressOut={onClickPay}>
-        <Text style={styles.buttonLabel}>Pay 250234 AED using Card</Text>
+        <Text style={styles.buttonLabel}>Pay 1 AED using Card</Text>
       </TouchableHighlight>
       {showWallet && (
         <TouchableHighlight
@@ -382,7 +382,7 @@ const App = () => {
             Platform.OS === 'android' ? onClickSamsungPay : onClickApplePay
           }>
           <Text style={styles.buttonLabel}>
-            {`Pay 250234 AED using ${Platform.OS === 'android' ? 'Samsung' : 'Apple'
+            {`Pay 1 AED using ${Platform.OS === 'android' ? 'Samsung' : 'Apple'
               } Pay`}
           </Text>
         </TouchableHighlight>
@@ -392,7 +392,7 @@ const App = () => {
           disabled={creatingOrder}
           style={StyleSheet.compose(styles.button, disabledStyle)}
           onPressOut={onClickGooglePay}>
-          <Text style={styles.buttonLabel}>Pay 250234 AED using Google Pay</Text>
+          <Text style={styles.buttonLabel}>Pay 1 AED using Google Pay</Text>
         </TouchableHighlight>
       )}
       <Text style={{ paddingVertical: 20 }}>

--- a/SimpleIntegration/src/ngenius-apis.js
+++ b/SimpleIntegration/src/ngenius-apis.js
@@ -6,6 +6,7 @@ import {
   API_KEY,
   IDENTITY_API_URL,
   GATEWAY_API_BASE_URL,
+  CREATE_ORDER_URL,
   PAYPAGE_API_URL,
   PAYPAGE_GATEWAY_URL,
 } from './config';
@@ -106,7 +107,7 @@ export const createToken = async () => {
       },
       data: {
         grantType: 'client_credentials',
-        realmName: 'newPayPageNoThreeDS',
+        realmName: 'NetworkInternational',
       },
     };
     
@@ -134,7 +135,7 @@ export const createOrder = async (accessToken, amount, savedCard = null) => {
     body.savedCard = savedCard;
   }
   const userAgent = await getUserAgent();
-  const { data } = await axios.post(GATEWAY_API_URL, body, {
+  const { data } = await axios.post(CREATE_ORDER_URL, body, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/vnd.ni-payment.v2+json',
@@ -261,7 +262,7 @@ export const getGooglePayConfig = async (accessToken, orderResponse = null) => {
       allowedPaymentMethods: ['VISA', 'MASTERCARD'],
       allowedAuthMethods: ['CRYPTOGRAM_3DS', 'PAN_ONLY'],
       gatewayName: 'networkintl',
-      environment: 'TEST',
+      environment: 'PRODUCTION',
       merchantInfo: {
         reference: outletIdFromToken || OUTLET_ID,
         name: 'Apple Pay Chub',

--- a/index.js
+++ b/index.js
@@ -250,7 +250,7 @@ const isGooglePaySupported = (googlePayConfig) => {
         reject({ status: 'Not Supported', error: 'Google Pay is not available' });
         return;
       }
-      const config = googlePayConfig || { environment: 'TEST' };
+      const config = googlePayConfig || { environment: 'PRODUCTION' };
       NiSdk.isGooglePaySupported(config, (isSupported) => {
         resolve(isSupported);
       });


### PR DESCRIPTION
- Set Google Pay environment defaults to PRODUCTION in app and SDK.
- Use prod realm and explicit create-order URL for gateway requests.
- Reduce the fixed demo amount to 1 AED and update UI labels.
- Update Android demo app id, version, and release signing output name.